### PR TITLE
Fix cache subdir

### DIFF
--- a/wpthumb.php
+++ b/wpthumb.php
@@ -302,6 +302,10 @@ class WP_Thumb {
 			$subdir = dirname( str_replace( $upload_dir['basedir'], '', $this->getFilePath() ) );
 			$new_dir = $upload_dir['basedir'] . '/cache' . $subdir . '/' . $filename_nice;
 
+		elseif ( strpos( $this->getFilePath(), WP_CONTENT_DIR ) === 0 ) :
+
+			$subdir = dirname( str_replace( WP_CONTENT_DIR, '', $this->getFilePath() ) );
+			$new_dir = $upload_dir['basedir'] . '/cache' . $subdir . '/' . $filename_nice;
 
 		elseif ( strpos( $this->getFilePath(), self::get_home_path() ) === 0 ) :
 			$new_dir = $upload_dir['basedir'] . '/cache/local';


### PR DESCRIPTION
When working out the cache directory, the subdir used was that returned from wp_uploads_dir(), and therefore the current directory path, which changed each month. This means that the cache is fully regenerated each month.

Fix this by deriving the subdir from the original file path.

Also do this for theme files passed through wpthumb.
