### PR TITLE
Bug admin edit page screwed

### DIFF
--- a/wpthumb.php
+++ b/wpthumb.php
@@ -634,7 +634,7 @@ function wpthumb_post_image( $null, $id, $args ) {
 	if ( ! empty( $args[1] ) )
 		$args['height'] = $args[1];
 
-	if ( ! empty( $args['crop'] ) && $args['crop'] && ! empty( $args['crop_from_position'] ) )
+	if ( ! empty( $args['crop'] ) && $args['crop'] && empty( $args['crop_from_position'] ) )
 		 $args['crop_from_position'] = get_post_meta( $id, 'wpthumb_crop_pos', true );
 
 	if ( empty( $path ) )


### PR DESCRIPTION
When crop to position was set, but crop was false, wpthumb tried to adjust the position, resulting in a broken image with large black sections.

To replicate, uploade a tall thin image, go to the edit media page in the admin, set crop to top center position.

This fix just prevents WPThumb cropping to position if crop it not set.
