### PR TITLE
Fix strict standards notice

### DIFF
--- a/wpthumb.php
+++ b/wpthumb.php
@@ -108,7 +108,7 @@ class WP_Thumb {
 
 		$upload_dir = self::uploadDir();
 		$this->_file_path = null;
-		
+
 		if ( strpos( $file_path, self::get_home_path() ) === 0 ) {
 			  $this->file_path = $file_path;
 			  return;
@@ -201,7 +201,7 @@ class WP_Thumb {
 			$this->file_path = $this->args['default'];
 
 		elseif ( ( ! $this->file_path ) && $this->args['default'] && file_exists( $this->args['default'] ) )
-			$this->file_path = $this->args['default'];			
+			$this->file_path = $this->args['default'];
 
         if ( $this->getArg( 'cache_with_query_params' ) )
             return $this->file_path;
@@ -299,7 +299,7 @@ class WP_Thumb {
 		$upload_dir = self::uploadDir();
 
 		if ( strpos( $this->getFilePath(), $upload_dir['basedir'] ) === 0 ) :
-			
+
 			$subdir = dirname( str_replace( $upload_dir['basedir'], '', $this->getFilePath() ) );
 			$new_dir = $upload_dir['basedir'] . '/cache' . $subdir . '/' . $filename_nice;
 
@@ -390,7 +390,7 @@ class WP_Thumb {
 
 			return $this->returnImage();
 		}
-		
+
 		wp_mkdir_p( $this->getCacheFileDirectory() );
 
 		// Convert gif images to png before resizing
@@ -421,7 +421,7 @@ class WP_Thumb {
 			$this->crop_from_center( $editor, $width, $height );
 
 		else :
-			
+
 			$editor->resize( $width, $height );
 		endif;
 
@@ -468,7 +468,7 @@ class WP_Thumb {
 				$_height = $height;
 			    $_width = $height * $ratio1;
 			}
-			
+
 			$editor->resize( $_width, $_height );
 		}
 
@@ -485,7 +485,7 @@ class WP_Thumb {
 		else if ( $position[1] == 'center' )
 			$crop['y'] = intval( absint( $size['height'] - $height ) / 2 );
 
-		
+
 		return $editor->crop( $crop['x'], $crop['y'], $width, $height );
 	}
 
@@ -644,7 +644,7 @@ function wpthumb_post_image( $null, $id, $args ) {
 
 	$path = apply_filters( 'wpthumb_post_image_path', $path, $id, $args );
 	$args = apply_filters( 'wpthumb_post_image_args', $args, $id );
-	
+
 	$image = new WP_Thumb( $path, $args );
 
 	$args = $image->getArgs();


### PR DESCRIPTION
Notice 

```
Strict Standards: Only variables should be passed by reference in .../wpthumb/wpthumb.php on line 209
```

Fixed by assigning the value returned by explode to a var before calling reset.

Also - accidentally committed a load of white space fixes even though I was trying not to! Sorry
