### PR TITLE
don't send travis build email notif, but send to hipchat room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
     - WP_VERSION=3.5.1 WP_MULTISITE=0
     - WP_VERSION=3.5.1 WP_MULTISITE=1
 
+notifications:
+    hipchat: bf3f28c944785dc22338ca32766a27@Servers
+    email: false
+
 before_script:
     - export WP_TESTS_DIR=/tmp/wordpress-tests/
     - bash bin/install-wp-tests.sh wordpress_test root '' $WP_VERSION 


### PR DESCRIPTION
can we stop sending the Travis CI notification email to support@hmn.md and send it to hipchat instead?
