### PR TITLE
Error when updating non-image attachemnt in admin

### DIFF
--- a/wpthumb.crop-from-position.php
+++ b/wpthumb.crop-from-position.php
@@ -69,7 +69,10 @@ function wpthumb_media_form_crop_position( $fields, $post ) {
  */
 function wpthumb_media_form_crop_position_save( $post, $attachment ){
 
-	if ( ! isset( $attachment['wpthumb_crop_pos'] ) || $attachment['wpthumb_crop_pos'] == 'center,center' )
+	if ( ! isset( $attachment['wpthumb_crop_pos'] ) )
+		return;
+	
+	if ( $attachment['wpthumb_crop_pos'] == 'center,center' )
 		delete_post_meta( $post['ID'], 'wpthumb_crop_pos' );
 
 	else


### PR DESCRIPTION
To reproduce:

Upload pdf file to WP.
Go to pdf in media library
click update
Get errors.
