### PR TITLE
Fixing php throwing a warning with extract

### DIFF
--- a/wpthumb.php
+++ b/wpthumb.php
@@ -437,7 +437,7 @@ class WP_Thumb {
 
 		apply_filters( 'wpthumb_image_pre', $editor, $this->args );
 
-		extract( $this->args );
+		if (is_array($this->args)) extract( $this->args );
 
 		// Cropping
 		if ( $crop && $crop_from_position && $crop_from_position !== array( 'center', 'center' ) ) :


### PR DESCRIPTION
If the args passed to extract are not an array php throws an error. Added a check to make sure the args are an array before running extract.
