### PR TITLE
Load main plugin file properly in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
 		"issues": "https://github.com/humanmade/WPThumb/issues"
 	},
 	"autoload"   : {
-		"classmap": ["wpthumb.php"]
+		"files": ["wpthumb.php"]
 	}
 }


### PR DESCRIPTION
Currently, in `composer.json` the main plugin file is loaded as a `classmap` class.

This will work only if you want to access the `WP_Thumb` class, but not if you want to use any of the WPThumb functions (like `wpthumb()` for example).

With this modification Composer's autoloader will always load the main plugin file, allowing developers to use any WPThumb function.
